### PR TITLE
Improve filesystem security in containers

### DIFF
--- a/docker/csp-reporter/Dockerfile
+++ b/docker/csp-reporter/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache curl
 
 # App setup
 WORKDIR /srv/http/backend
-RUN adduser -D -g http http
+RUN adduser -D -H -g http http
 COPY --from=backend-build /srv/http/backend/.env ./
 COPY --from=backend-build /usr/local/bin/csp-reporter /go/bin/asynq /usr/local/bin/
 COPY --from=backend-build /srv/http/backend/keys/ keys/
@@ -35,7 +35,7 @@ COPY --from=backend-build /srv/http/backend/templates/ templates/
 COPY --from=backend-build /srv/http/backend/tasks/config.yml tasks/
 
 # Filesystem setup
-RUN chown -R http:http .
+RUN chown -R http:http -- tasks/config.yml
 
 # Non-root user
 USER http

--- a/docker/csp-reporter/dev.dockerfile
+++ b/docker/csp-reporter/dev.dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache curl
 
 # App setup
 WORKDIR /srv/http/backend
-RUN adduser -D -g http http
+RUN adduser -D -H -g http http
 COPY --from=backend-build /srv/http/backend/.env ./
 COPY --from=backend-build /usr/local/bin/csp-reporter /go/bin/asynq /usr/local/bin/
 COPY --from=backend-build /srv/http/backend/keys/ keys/
@@ -36,7 +36,7 @@ COPY --from=backend-build /srv/http/backend/templates/ templates/
 COPY --from=backend-build /srv/http/backend/tasks/config.yml tasks/
 
 # Filesystem setup
-RUN chown -R http:http .
+RUN chown -R http:http -- tasks/config.yml
 
 # Non-root user
 USER http

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -19,8 +19,22 @@ LABEL maintainer "Alfredo Ramos <alfredoramos@duck.com>"
 
 # App setup
 WORKDIR /srv/http/frontend
-RUN adduser -D -g http http
 COPY --from=frontend-build /srv/http/frontend/dist/ dist/
 
 # Filesystem setup
-RUN chown -R http:http .
+RUN mkdir -p /var/cache/nginx/client_temp \
+	/var/cache/nginx/proxy_temp \
+	/var/cache/nginx/fastcgi_temp \
+	/var/cache/nginx/uwsgi_temp \
+	/var/cache/nginx/scgi_temp && \
+	touch /var/run/nginx.pid && \
+	chown -R nginx:nginx /etc/nginx/ \
+	/var/cache/nginx \
+	/var/log/nginx \
+	/var/run/nginx.pid /run/nginx.pid
+
+# Non-root user
+USER nginx
+
+# Start server
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,4 +1,4 @@
-user nginx;
+pid /var/run/nginx.pid;
 
 # May be equal to `grep processor /proc/cpuinfo | wc -l`
 worker_processes auto;
@@ -20,6 +20,12 @@ events {
 }
 
 http {
+	client_body_temp_path /tmp/client_temp;
+	proxy_temp_path /tmp/proxy_temp_path;
+	fastcgi_temp_path /tmp/fastcgi_temp;
+	uwsgi_temp_path /tmp/uwsgi_temp;
+	scgi_temp_path /tmp/scgi_temp;
+
 	charset utf-8;
 	# Disables the “Server” response header
 	server_tokens off;


### PR DESCRIPTION
- [x] Set read-only permissions for the non-root user in the backend.
- [x] Disable home directory for user `http`.
- [x] Allow to modify only the task config file in the backend since the tasks are dynamic on Asynq.
- [x] Run Nginx reverse proxy as non-root user.